### PR TITLE
PEP333 requires wsgi.run_once, and hgwebdir needs it

### DIFF
--- a/m2wsgi/io/base.py
+++ b/m2wsgi/io/base.py
@@ -990,6 +990,7 @@ class WSGIHandler(Handler):
         environ['wsgi.multithread'] = True
         environ['wsgi.multiprocess'] = False
         environ['wsgi.url_scheme'] = "http"
+        environ['wsgi.run_once'] = False
         #  Include the HTTP headers
         for (k,v) in req.headers.iteritems():
             #  The mongrel2 headers dict contains lots of things


### PR DESCRIPTION
I decided to take a few minutes tonight to get hgwebdir (mercurial web frontend) running under m2wsgi, and it insists on the availability of wsgi.run_once; a quick check of PEP333 shows that it's a required variable, so here's a quick patch to add a sane default for it.

http://www.python.org/dev/peps/pep-0333/
