### PR TITLE
Fixed a bug using m2wsgi with webob.

### DIFF
--- a/m2wsgi/io/base.py
+++ b/m2wsgi/io/base.py
@@ -951,7 +951,7 @@ class WSGIHandler(Handler):
             #  might e.g. move them somewhere.  We just read from them.
             try:
                 environ["wsgi.input"].close()
-            except KeyError:
+            except (KeyError, AttributeError):
                 pass
             upload_file = req.headers.get("x-mongrel2-upload-start",None)
             if upload_file:


### PR DESCRIPTION
The problem is that webob converts the request body environ['wsgi.input']
into a FakeCGIBody object which does not implement the close() method.

Traceback (most recent call last):
  File "/home/example/env/lib/python2.7/site-packages/gevent/greenlet.py    def **init**(self,_args,__kwds):
", line 390, in run
    result = self._run(_self.args, **self.kwargs)
  File "/home/example/env/src/m2wsgi/m2wsgi/io/gevent.py", line 220, in do_handle_request
    self.process_request(req)
  File "/home/example/env/src/m2wsgi/m2wsgi/io/base.py", line 953, in process_request
    environ["wsgi.input"].close()
AttributeError: 'FakeCGIBody' object has no attribute 'close'
<Greenlet at 0x2e63c00: do_handle_request> failed with AttributeError
